### PR TITLE
Fix: 회원가입 401 버그 수정

### DIFF
--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -55,15 +55,21 @@ const JoinForm = () => {
 
     if (!validateForm()) return;
 
+    // setIsLoading(true);
+
     try {
       const { email, password, name, nickname } = formData;
-      await authApi.join(email, password, name, nickname);
-      // navigate("/login");
+      // profilePicture를 null로
+      await authApi.join(email, password, name, nickname, null);
+
+      navigate("/login");
     } catch (error) {
       setErrors((prev) => ({
         ...prev,
-        submit: error.message,
+        submit: error.message || "회원가입 처리 중 오류가 발생했습니다.",
       }));
+    } finally {
+      // setIsLoading(false);
     }
   };
 

--- a/src/services/api/authApi.js
+++ b/src/services/api/authApi.js
@@ -49,7 +49,7 @@ export const authApi = {
         formData.append("profilePicture", new Blob([]));
       }
 
-      const response = await api.post("/auth/join", formData, {
+      const response = await api.post("/join", formData, {
         headers: {
           "Content-Type": "multipart/form-data",
         },
@@ -57,6 +57,11 @@ export const authApi = {
 
       return response.data;
     } catch (error) {
+      console.error("Join error:", {
+        message: error.message,
+        response: error.response,
+        data: error.response?.data,
+      });
       throw new Error(
         error.response?.data?.message || "회원가입 처리 중 오류가 발생했습니다."
       );

--- a/src/services/api/axios.js
+++ b/src/services/api/axios.js
@@ -19,7 +19,8 @@ api.interceptors.request.use(
     console.log(accessToken);
     console.log("access토큰 아직있음");
 
-    if (accessToken) {
+    // 회원가입 요청에는 Authorization 헤더를 추가하지 않음
+    if (accessToken && !config.url.includes("/auth/join")) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;


### PR DESCRIPTION
# 수정 내용

```
const handleSubmit = async (e) => {
  e.preventDefault();

  if (!validateForm()) return;

  setIsLoading(true);
  try {
    const { email, password, name, nickname } = formData;

    // profilePicture를 null로 명시적으로 포함
    await authApi.join(email, password, name, nickname, null);

    navigate("/login");
```
#### 이외 수정 내용: API 요청 경로 변경
- `authApi.js`에서 엔드포인트를 `/join`으로 경로 일치시킴

# 결과 확인
### 회원가입 내역 확인
![image](https://github.com/user-attachments/assets/24cb9cec-bbd2-44b2-ac2f-4d18e0982d8f)

### 회원가입 직후 로그인 페이지로 redirect됨
![image](https://github.com/user-attachments/assets/91e0c7ac-8f3e-4db4-8c8a-afecf0c7c6c6)
