### PR TITLE
Feat: 유효성 검사 로직 개선 및 조건 추가

### DIFF
--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -1,8 +1,12 @@
-// components/auth/JoinForm.jsx
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { authApi } from "../../services/api/authApi";
-import { validateEmail, validatePassword } from "../../utils/validation";
+import {
+  validateEmail,
+  validatePassword,
+  validateName,
+  validateNickname,
+} from "../../utils/validation";
 import AuthInput from "./AuthInput.jsx";
 
 const JoinForm = () => {
@@ -15,6 +19,7 @@ const JoinForm = () => {
     nickname: "",
   });
   const [errors, setErrors] = useState({});
+  const [isFormValid, setIsFormValid] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -22,57 +27,72 @@ const JoinForm = () => {
       ...prev,
       [name]: value,
     }));
-    if (errors[name]) {
-      setErrors((prev) => ({
-        ...prev,
-        [name]: "",
-      }));
-    }
+
+    // 입력값 변경에 따른 실시간 유효성 검사
+    validateField(name, value);
   };
 
-  const validateForm = () => {
-    const newErrors = {};
+  const validateField = (name, value) => {
+    let errorMessage = "";
+    switch (name) {
+      case "email":
+        errorMessage = !validateEmail(value)
+          ? "유효한 이메일 주소를 입력해주세요"
+          : "";
+        break;
+      case "password":
+        errorMessage = validatePassword(value, formData.email);
+        break;
+      case "confirmpassword":
+        errorMessage = value !== formData.password 
+          ? "비밀번호가 일치하지 않습니다" 
+          : "";
+        break;
+      case "name":
+        errorMessage = validateName(value);
+        break;
+      case "nickname":
+        errorMessage = validateNickname(value);
+        break;
+    }
 
-    if (!validateEmail(formData.email)) {
-      newErrors.email = "유효한 이메일 주소를 입력해주세요";
-    }
-    if (!validatePassword(formData.password)) {
-      newErrors.password = "비밀번호는 8자 이상이어야 합니다";
-    }
-    if (formData.password !== formData.confirmpassword) {
-      newErrors.confirmpassword = "비밀번호가 일치하지 않습니다";
-    }
-    if (!formData.name.trim()) {
-      newErrors.name = "이름을 입력해주세요";
-    }
-    if (!formData.nickname.trim()) {
-      newErrors.nickname = "닉네임을 입력해주세요";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    setErrors((prev) => ({
+      ...prev,
+      [name]: errorMessage,
+    }));
   };
+
+  useEffect(() => {
+    // 모든 필드 유효성 검사
+    const isValid =
+      formData.email.trim() !== "" &&
+      formData.password.trim() !== "" &&
+      formData.confirmpassword.trim() !== "" &&
+      formData.name.trim() !== "" &&
+      formData.nickname.trim() !== "" &&
+      !errors.email &&
+      !errors.password &&
+      !errors.confirmpassword &&
+      !errors.name &&
+      !errors.nickname;
+
+    setIsFormValid(isValid);
+  }, [formData, errors]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    if (!validateForm()) return;
-
-    // setIsLoading(true);
+    if (!isFormValid) return;
 
     try {
       const { email, password, name, nickname } = formData;
-      // profilePicture를 null로
       await authApi.join(email, password, name, nickname, null);
-
       navigate("/login");
     } catch (error) {
       setErrors((prev) => ({
         ...prev,
         submit: error.message || "회원가입 처리 중 오류가 발생했습니다.",
       }));
-    } finally {
-      // setIsLoading(false);
     }
   };
 
@@ -94,7 +114,7 @@ const JoinForm = () => {
         value={formData.password}
         onChange={handleChange}
         error={errors.password}
-        placeholder="8자 이상 입력해주세요"
+        placeholder="8-16자로 입력해주세요"
       />
       <AuthInput
         label="비밀번호 확인"
@@ -130,7 +150,12 @@ const JoinForm = () => {
 
       <button
         type="submit"
-        className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+        disabled={!isFormValid}
+        className={`w-full font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline ${
+          isFormValid
+            ? "bg-indigo-600 hover:bg-indigo-700 text-white"
+            : "bg-gray-400 text-gray-200 cursor-not-allowed"
+        }`}
       >
         회원가입
       </button>

--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -10,6 +10,7 @@ const JoinForm = () => {
   const [formData, setFormData] = useState({
     email: "",
     password: "",
+    confirmpassword: "",
     name: "",
     nickname: "",
   });
@@ -21,7 +22,6 @@ const JoinForm = () => {
       ...prev,
       [name]: value,
     }));
-    // 실시간 에러 초기화
     if (errors[name]) {
       setErrors((prev) => ({
         ...prev,
@@ -38,6 +38,9 @@ const JoinForm = () => {
     }
     if (!validatePassword(formData.password)) {
       newErrors.password = "비밀번호는 8자 이상이어야 합니다";
+    }
+    if (formData.password !== formData.confirmpassword) {
+      newErrors.confirmpassword = "비밀번호가 일치하지 않습니다";
     }
     if (!formData.name.trim()) {
       newErrors.name = "이름을 입력해주세요";
@@ -92,6 +95,15 @@ const JoinForm = () => {
         onChange={handleChange}
         error={errors.password}
         placeholder="8자 이상 입력해주세요"
+      />
+      <AuthInput
+        label="비밀번호 확인"
+        name="confirmpassword"
+        type="password"
+        value={formData.confirmpassword}
+        onChange={handleChange}
+        error={errors.confirmpassword}
+        placeholder="비밀번호를 다시 입력해주세요"
       />
       <AuthInput
         label="이름"

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -13,7 +13,7 @@ export const validatePassword = (password, email = "") => {
   const isEmailPart = emailPrefix && password.includes(emailPrefix); // 이메일 vs 비밀번호
 
   if (!passwordRegex.test(password)) {
-    return "비밀번호는 영문, 숫자, 특수문자를 포함해 8~12자로 작성해주세요";
+    return "비밀번호는 영문, 숫자, 특수문자를 포함해 8~16자로 작성해주세요";
   }
   if (containsKorean.test(password)) {
     return "비밀번호에 한글은 포함될 수 없습니다";
@@ -36,20 +36,19 @@ export const validateName = (name) => {
     if (name.length < 2) {
       return "이름은 최소 2글자 이상이어야 합니다.";
     }
-  } 
+  }
   // 영어인 경우
   else if (fullEnglishRegex.test(name)) {
     if (name.length < 2) {
       return "이름은 최소 2글자 이상이어야 합니다.";
     }
-  } 
+  }
   // 한글이나 영어가 아닌 경우
   else {
     return "이름은 완전한 한글 또는 영어로 입력해야 합니다.";
   }
   return "";
 };
-
 
 // 닉네임 유효성 검사(영어, 한글만 포함 2~12자)
 export const validateNickname = (nickname) => {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,9 +1,61 @@
+// 이메일 유효성 검사
 export const validateEmail = (email) => {
   const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return regex.test(email);
 };
 
-export const validatePassword = (password) => {
-  const minLength = 8;
-  return password.length >= minLength;
+// 비밀번호 유효성 검사(영문, 숫자, 특수문자 조합 8~16자)
+export const validatePassword = (password, email = "") => {
+  const passwordRegex =
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
+  const containsKorean = /[ㄱ-ㅎㅏ-ㅣ가-힣]/;
+  const emailPrefix = email ? email.split("@")[0] : ""; // 이메일의 @앞 부분
+  const isEmailPart = emailPrefix && password.includes(emailPrefix); // 이메일 vs 비밀번호
+
+  if (!passwordRegex.test(password)) {
+    return "비밀번호는 영문, 숫자, 특수문자를 포함해 8~12자로 작성해주세요";
+  }
+  if (containsKorean.test(password)) {
+    return "비밀번호에 한글은 포함될 수 없습니다";
+  }
+  if (isEmailPart) {
+    return "비밀번호는 이메일과 동일하게 설정할 수 없습니다";
+  }
+  return "";
+};
+
+// 이름 유효성 검사
+export const validateName = (name) => {
+  const fullKoreanRegex = /^[가-힣]+$/; // 완전한 한글로만 구성된 경우
+  const fullEnglishRegex = /^[A-Za-z]+$/; // 영어로만 구성된 경우
+  if (!name.trim()) {
+    return "이름을 입력해주세요.";
+  }
+  // 한글인 경우
+  if (fullKoreanRegex.test(name)) {
+    if (name.length < 2) {
+      return "이름은 최소 2글자 이상이어야 합니다.";
+    }
+  } 
+  // 영어인 경우
+  else if (fullEnglishRegex.test(name)) {
+    if (name.length < 2) {
+      return "이름은 최소 2글자 이상이어야 합니다.";
+    }
+  } 
+  // 한글이나 영어가 아닌 경우
+  else {
+    return "이름은 완전한 한글 또는 영어로 입력해야 합니다.";
+  }
+  return "";
+};
+
+
+// 닉네임 유효성 검사(영어, 한글만 포함 2~12자)
+export const validateNickname = (nickname) => {
+  const nicknameRegex = /^[A-Za-z가-힣]{2,12}$/;
+  if (!nicknameRegex.test(nickname)) {
+    return "닉네임은 영어 또는 한글만 포함하여, 2~12자로 작성해주세요.";
+  }
+  return "";
 };


### PR DESCRIPTION
# 유효성 검사
- 비밀번호, 이름, 닉네임 유효성 검사 로직 개선 및 조건 추가
- 특히 **이름**의 경우, 3가지 경우에 따라 사용자에게 상세한 유효성 검사 메시지 제공
  - 이름이 한글로 작성되어있는 경우, 완전한 한글이 아니라면 '이름은 완전한 한글로 입력해야 합니다.'
  - 완전한 한글이지만 2글자 이상이 아니라면 '이름은 최소 2글자 이상이어야 합니다'
  - 영어로 작성되어 있지만 이름이 2글자 이상이 아니라면 '이름은 최소 2글자 이상이어야 합니다'
<img src="https://github.com/user-attachments/assets/5bca65bb-2b0a-4cc5-bff3-328a650397d9" width="45%" style="margin-right: 10px;"/>
<img src="https://github.com/user-attachments/assets/a11884e1-8b64-4f3f-92bf-0b389685d6bc" width="45%" />

<img src="https://github.com/user-attachments/assets/64a2c8a5-8612-4685-8621-be47a4987343" width="45%" style="margin-right: 10px;"/>
<img src="https://github.com/user-attachments/assets/3766b64b-22fb-4115-a1cc-8140489d5f49" width="45%" />

1. `비밀번호`
- 영어, 숫자, 특수문자 모두 포함, 8~16글자
2. `이름`
- **한글**: 완전한 한글로만 작성되었다면 최소 2글자 이상이어야 유효
- **영어**: 최소 2글자 이상이어야 유효
3. `닉네임`
- 영어와 한글만 허용, 2~12글자