### PR TITLE
Feat: 회원가입 알림 및 닉네임 중복 확인 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.3",
-        "recoil": "^0.7.7"
+        "recoil": "^0.7.7",
+        "sweetalert2": "^11.15.10"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -5423,6 +5424,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.15.10",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.15.10.tgz",
+      "integrity": "sha512-Sjiwcd5mWiz8X0JFkHsso2EPVQHrLCjVv+xR6Ry2LKf4KY6kSi4U5pM0Tgmn1c7SMfkyDqPal2NWqwj6vck8bw==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.3",
-    "recoil": "^0.7.7"
+    "recoil": "^0.7.7",
+    "sweetalert2": "^11.15.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -21,7 +21,9 @@ const JoinForm = () => {
   });
   const [errors, setErrors] = useState({});
   const [isFormValid, setIsFormValid] = useState(false);
-  const [isNicknameValid, setIsNicknameValid] = useState(false);
+
+  // #### 닉네임 이 부분 주석 제거거
+  // const [isNicknameValid, setIsNicknameValid] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -30,14 +32,18 @@ const JoinForm = () => {
       [name]: value,
     }));
 
+
+    // #### 닉네임 아래 주석 풀기 ####
     //닉네임 변경 시 중복 확인 초기화
-    if (name === "nickname") {
-      setIsNicknameValid(false);
-    }
+    // if (name === "nickname") {
+    //   setIsNicknameValid(false);
+    // }
 
     // 입력값 변경에 따른 실시간 유효성 검사
     validateField(name, value);
   };
+
+
 
   const validateField = (name, value) => {
     let errorMessage = "";
@@ -68,30 +74,34 @@ const JoinForm = () => {
     }));
   };
 
-  const handleCheckNickname = async () => {
-    // 닉네임 중복 확인 API 호출 부분
-    try {
-      const isAvailable = await authApi.checkNickname(formData.nickname);
-      if (isAvailable) {
-        Swal.fire({
-          icon: "success",
-          text: "사용 가능한 닉네임입니다.",
-        });
-        setIsNicknameValid(true);
-      } else {
-        Swal.fire({
-          icon: "error",
-          text: "이미 사용 중인 닉네임입니다.",
-        });
-        setIsNicknameValid(false);
-      }
-    } catch (error) {
-      Swal.fire({
-        icon: "error",
-        text: "닉네임 중복 확인 중 오류가 발생했습니다.",
-      });
-    }
-  };
+
+  // #### 닉네임 중복 확인 ####
+  // const handleCheckNickname = async () => {
+  //   // 닉네임 중복 확인 API 호출 부분
+  //   try {
+  //     const isAvailable = await authApi.checkNickname(formData.nickname);
+  //     if (isAvailable) {
+  //       Swal.fire({
+  //         icon: "success",
+  //         text: "사용 가능한 닉네임입니다.",
+  //       });
+  //       setIsNicknameValid(true);
+  //     } else {
+  //       Swal.fire({
+  //         icon: "error",
+  //         text: "이미 사용 중인 닉네임입니다.",
+  //       });
+  //       setIsNicknameValid(false);
+  //     }
+  //   } catch (error) {
+  //     Swal.fire({
+  //       icon: "error",
+  //       text: "닉네임 중복 확인 중 오류가 발생했습니다.",
+  //     });
+  //   }
+  // };
+
+
 
   useEffect(() => {
     // 모든 필드 유효성 검사
@@ -105,11 +115,15 @@ const JoinForm = () => {
       !errors.password &&
       !errors.confirmpassword &&
       !errors.name &&
-      !errors.nickname &&
-      isNicknameValid;
+      !errors.nickname;
 
-    setIsFormValid(isValid);
-  }, [formData, errors, isNicknameValid]);
+      // #### 닉네임 중복 확인 아래 3줄 주석 풀고 밑에 두 줄 지우기 ###
+      // isNicknameValid;
+  //   setIsFormValid(isValid);
+  // }, [formData, errors, isNicknameValid]);
+
+      setIsFormValid(isValid);
+  }, [formData, errors]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -192,13 +206,18 @@ const JoinForm = () => {
             placeholder="닉네임을 입력해주세요"
           />
         </div>
-        <button
+
+
+        {/* ##### 닉네임 중복 확인 #### */}
+        {/* <button
           type="button"
           onClick={handleCheckNickname}
           className="bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded focus:outline-none"
         >
           닉네임 중복 확인
-        </button>
+        </button> */}
+
+
       </div>
 
       {errors.submit && (

--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -8,6 +8,7 @@ import {
   validateNickname,
 } from "../../utils/validation";
 import AuthInput from "./AuthInput.jsx";
+import Swal from "sweetalert2";
 
 const JoinForm = () => {
   const navigate = useNavigate();
@@ -44,9 +45,8 @@ const JoinForm = () => {
         errorMessage = validatePassword(value, formData.email);
         break;
       case "confirmpassword":
-        errorMessage = value !== formData.password 
-          ? "비밀번호가 일치하지 않습니다" 
-          : "";
+        errorMessage =
+          value !== formData.password ? "비밀번호가 일치하지 않습니다" : "";
         break;
       case "name":
         errorMessage = validateName(value);
@@ -87,13 +87,26 @@ const JoinForm = () => {
     try {
       const { email, password, name, nickname } = formData;
       await authApi.join(email, password, name, nickname, null);
-      alert("회원가입이 완료되었습니다")
+
+      await Swal.fire({
+        icon: "success",
+        title: "회원가입 완료",
+        text: "회원가입이 정상적으로 완료되었습니다.",
+        confirmButtonText: "로그인 페이지로 이동",
+      });
       navigate("/login");
     } catch (error) {
       setErrors((prev) => ({
         ...prev,
         submit: error.message || "회원가입 처리 중 오류가 발생했습니다.",
       }));
+
+      Swal.fire({
+        icon: "error",
+        title: "오류 발생",
+        text: error.message || "회원가입 처리 중 오류가 발생했습니다.",
+        confirmButtonText: "확인",
+      });
     }
   };
 

--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -21,6 +21,7 @@ const JoinForm = () => {
   });
   const [errors, setErrors] = useState({});
   const [isFormValid, setIsFormValid] = useState(false);
+  const [isNicknameValid, setIsNicknameValid] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -28,6 +29,11 @@ const JoinForm = () => {
       ...prev,
       [name]: value,
     }));
+
+    //닉네임 변경 시 중복 확인 초기화
+    if (name === "nickname") {
+      setIsNicknameValid(false);
+    }
 
     // 입력값 변경에 따른 실시간 유효성 검사
     validateField(name, value);
@@ -62,6 +68,31 @@ const JoinForm = () => {
     }));
   };
 
+  const handleCheckNickname = async () => {
+    // 닉네임 중복 확인 API 호출 부분
+    try {
+      const isAvailable = await authApi.checkNickname(formData.nickname);
+      if (isAvailable) {
+        Swal.fire({
+          icon: "success",
+          text: "사용 가능한 닉네임입니다.",
+        });
+        setIsNicknameValid(true);
+      } else {
+        Swal.fire({
+          icon: "error",
+          text: "이미 사용 중인 닉네임입니다.",
+        });
+        setIsNicknameValid(false);
+      }
+    } catch (error) {
+      Swal.fire({
+        icon: "error",
+        text: "닉네임 중복 확인 중 오류가 발생했습니다.",
+      });
+    }
+  };
+
   useEffect(() => {
     // 모든 필드 유효성 검사
     const isValid =
@@ -74,10 +105,11 @@ const JoinForm = () => {
       !errors.password &&
       !errors.confirmpassword &&
       !errors.name &&
-      !errors.nickname;
+      !errors.nickname &&
+      isNicknameValid;
 
     setIsFormValid(isValid);
-  }, [formData, errors]);
+  }, [formData, errors, isNicknameValid]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -103,7 +135,7 @@ const JoinForm = () => {
 
       Swal.fire({
         icon: "error",
-        title: "오류 발생",
+        title: "오류",
         text: error.message || "회원가입 처리 중 오류가 발생했습니다.",
         confirmButtonText: "확인",
       });
@@ -128,7 +160,7 @@ const JoinForm = () => {
         value={formData.password}
         onChange={handleChange}
         error={errors.password}
-        placeholder="8-16자로 입력해주세요"
+        placeholder="8~16자로 입력해주세요"
       />
       <AuthInput
         label="비밀번호 확인"
@@ -148,15 +180,26 @@ const JoinForm = () => {
         error={errors.name}
         placeholder="이름을 입력해주세요"
       />
-      <AuthInput
-        label="닉네임"
-        name="nickname"
-        type="text"
-        value={formData.nickname}
-        onChange={handleChange}
-        error={errors.nickname}
-        placeholder="닉네임을 입력해주세요"
-      />
+      <div className="flex items-center space-x-2">
+        <div className="flex-1">
+          <AuthInput
+            label="닉네임"
+            name="nickname"
+            type="text"
+            value={formData.nickname}
+            onChange={handleChange}
+            error={errors.nickname}
+            placeholder="닉네임을 입력해주세요"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleCheckNickname}
+          className="bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded focus:outline-none"
+        >
+          닉네임 중복 확인
+        </button>
+      </div>
 
       {errors.submit && (
         <div className="text-red-500 text-sm text-center">{errors.submit}</div>

--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -87,6 +87,7 @@ const JoinForm = () => {
     try {
       const { email, password, name, nickname } = formData;
       await authApi.join(email, password, name, nickname, null);
+      alert("회원가입이 완료되었습니다")
       navigate("/login");
     } catch (error) {
       setErrors((prev) => ({

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-
 @font-face {
   font-family: "CookieRun";
-  src: url("/public/fonts/CookieRun-Regular.ttf" ) format("truetype");
+  src: url("/public/fonts/CookieRun-Regular.ttf") format("truetype");
   font-display: swap;
 }
 
@@ -17,3 +16,5 @@
 body * {
   font-family: "CookieRun";
 }
+
+@import "sweetalert2/dist/sweetalert2.min.css";


### PR DESCRIPTION
## 회원가입 성공 시 알림 기능 추가(SweetAlert2)
![image](https://github.com/user-attachments/assets/b98fd21c-7df7-44ea-bd2b-f7fe7c56574e)
- 이후 버튼 클릭 시 로그인 페이지로 이동할 수 있도록 수정
- 기존 로직: 회원가입 성공 시 바로 로그인 페이지로 redirect
## 닉네임 중복 확인 기능 관련 코드 주석처리 (백엔드 구현 대기)
```
  // const handleCheckNickname = async () => {
  //   // 닉네임 중복 확인 API 호출 부분
  //   try {
  //     const isAvailable = await authApi.checkNickname(formData.nickname);
  //     if (isAvailable) {
  //       Swal.fire({
  //         icon: "success",
  //         text: "사용 가능한 닉네임입니다.",
  //       });
  //       setIsNicknameValid(true);
  //     } else {
  //       Swal.fire({
  //         icon: "error",
  //         text: "이미 사용 중인 닉네임입니다.",
  //       });
  //       setIsNicknameValid(false);
  //     }
  //   } catch (error) {
  //     Swal.fire({
  //       icon: "error",
  //       text: "닉네임 중복 확인 중 오류가 발생했습니다.",
  //     });
  //   }
  // };

```